### PR TITLE
Issue5 auto adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+wsl2_boot.log

--- a/configureWSL2Net.sh
+++ b/configureWSL2Net.sh
@@ -3,4 +3,3 @@
 sudo ip addr flush eth0 && sudo ip addr add 192.168.1.10/24 brd + dev eth0 && sudo ip route delete default; sudo ip route add default via 192.168.1.1
 # run docker deamon and enjoy your hassle free containers.
 sudo dockerd
-

--- a/readme.md
+++ b/readme.md
@@ -2,12 +2,20 @@ How to run WSL2 and Hyper-V VMs as if your Linux was normal VM, with own ip addr
 no redirects needed. no *special* software. 
 As it should have been from the start. or As if MS decided not to overwrite your config every single reboot.
 
-Linux:
+### Windows
+_Scripts assume they're installed to C:\Startup. Adjust to local machine accordingly._
+
+Clone this code repository somewhere and make it appear as `C:\Startup` in Windows and have linux `$HOME/WSL2-Network-Fix` point to the same place:
+
+    git clone https://github.com/pawelgnatowski/WSL2-Network-Fix.git
+    pushd WSL2-Network-Fix
+    mklink /d C:\Startup %cd%
+    wsl -u root bash -c "ln -s ~/mnt/c/Startup"
+
+### Linux
 wsl.conf => disable resolv.conf recreation
 
 resolv.conf => set flag to +i so windows will not overwrite the file despite the docs saying wsl.conf is enough. it is not. MS plainly ignores wsl.conf file and its own docs.
-
-put the script (configureWSL2Net.sh) somewhere in your WSL2 instance  and mark executable it to +x.conf
 
 setup the task scheduler on startup AFTER LOGIN - 30 seconds delay to run => start.bat
 make sure paths are correct in the files. 

--- a/resetWindowsNet.ps1
+++ b/resetWindowsNet.ps1
@@ -30,7 +30,7 @@ function ConfigureWSLNetwork {
     
     # wsl --distribution Ubuntu-20.04 -u root /home/p/configureWSL2Net.sh
     # configureWSL2Net.sh needs to be made executable
-    Start-Process -FilePath "wsl.exe" -ArgumentList "-u root /home/p/configureWSL2Net.sh"
+    Start-Process -FilePath "wsl.exe" -ArgumentList "-u root /mnt/c/Startup/configureWSL2Net.sh"
     Write-Output "network configuration completed" >> $logPath
     
     Write-Output $wslStatus 5>> $logPath

--- a/resetWindowsNet.ps1
+++ b/resetWindowsNet.ps1
@@ -47,15 +47,15 @@ wsl exit
 wsl -l -v *>> $logPath
 
 $started = $false
-$err = @() 
+$err = @()
 
 Do {
     $status = Get-VMSwitch WSL -ErrorAction SilentlyContinue -ErrorVariable +err
     Write-Output $status >> $logPath
-    If ($err[0] -match 'do not have required permission') { Write-Output $err >> $logPath; throw $err }
+    If ($err[0] -match "do not have the required permission") { Write-Output $err >> $logPath; throw $err }
     If ($err.count -eq 10) {Write-Output '*** Error No WSL VM switch after 10 attempts' >> $logPath; throw $err}
 
-    If (!($status)) { Write-Output 'Waiting for WSL swtich to get registered' ; Start-Sleep 1 }
+    If (!($status)) { Write-Output 'Waiting for WSL swtich to get registered ', $err.count ; Start-Sleep 1 }
     Else {
         Write-Output  "WSL Network found" ; 
         $started = $true; 

--- a/resetWindowsNet.ps1
+++ b/resetWindowsNet.ps1
@@ -65,7 +65,8 @@ Do {
 
         # identify non-virtual adapters with active network connection
         # $active[0] will be 1st net adapter in list while $active.[-1] will be last one
-        $active = Get-NetAdapter | Where-Object Status -eq up | Where-Object InterfaceDescription -NotMatch 'Virtual' ;
+        $active = Get-NetAdapter | Where-Object Status -eq up | Where-Object InterfaceDescription -NotMatch 'Virtual' |
+            Where-Object Name -NotMatch 'Bridge' ;
   
         # Disable the vm adapter bound to active connection.
         ## Set-NetAdapterBinding -Name "Ethernet" -ComponentID vms_pp -Enabled $False ;

--- a/resetWindowsNet.ps1
+++ b/resetWindowsNet.ps1
@@ -57,7 +57,7 @@ Do {
 
     If (!($status)) { Write-Output 'Waiting for WSL swtich to get registered ', $err.count ; Start-Sleep 1 }
     Else {
-        Write-Output  "WSL Network found" ; 
+        Write-Output  "WSL Network found: $status" ; 
         $started = $true; 
         # manipulate network adapter tickboxes - Adapter cannot be bound because binding to Hyper-V is still there after M$ windows restarts.
         # Get-NetAdapterBinding Ethernet to view components of the interface vms_pp is what we look for
@@ -74,6 +74,12 @@ Do {
 
         #Set-VMSwitch WSL -NetAdapterName "Ethernet" ;
         Set-VMSwitch WSL -NetAdapterName $active[0].Name ;
+
+        # Cycle the adapter state to ensure connection still active, mitigates Issue #8: No network after Set-VMSwitch WSL ...
+        # https://github.com/pawelgnatowski/WSL2-Network-Fix/issues/8
+        Disable-NetAdapter  -Name $active[0].Name -Confirm:$false ;
+        Enable-NetAdapter -Name $active[0].Name ;
+
         $started = $true ;
         # Hook all Hyper V VMs to WSL network => avoid network performance issues.
         Write-Output  "Getting all Hyper V machines to use WSL Switch" >> $logPath ; 

--- a/resetWindowsNet.ps1
+++ b/resetWindowsNet.ps1
@@ -10,14 +10,14 @@ function ConfigureWSLNetwork {
      
     Write-Output "Starting WSL..." >> $logPath
     
-    $wslStatus = Get-Process -Name "wsl" -ErrorAction Continue
+    $wslStatus = Get-Process -Name "wsl" -ErrorAction Inquire
     if (!($wslStatus)) {
         Start-Job -ScriptBlock { Start-Process -FilePath "wsl.exe" -WindowStyle hidden }
     }   
     
     Do {
 
-        $wslStatus = Get-Process -Name "wsl" -ErrorAction Continue
+        $wslStatus = Get-Process -Name "wsl" -ErrorAction Inquire
     
         If (!($wslStatus)) { Write-Output 'Waiting for WSL2 process to start' >> $logPath ; Start-Sleep 1 }
         
@@ -65,7 +65,7 @@ Do {
 
         # identify non-virtual adapters with active network connection
         # $active[0] will be 1st net adapter in list while $active.[-1] will be last one
-        $active = Get-NetAdapter | Where-Object Status -eq up | Where-Object Name -NotMatch 'Virtual' ;
+        $active = Get-NetAdapter | Where-Object Status -eq up | Where-Object InterfaceDescription -NotMatch 'Virtual' ;
   
         # Disable the vm adapter bound to active connection.
         ## Set-NetAdapterBinding -Name "Ethernet" -ComponentID vms_pp -Enabled $False ;
@@ -78,6 +78,7 @@ Do {
         Write-Output  "Getting all Hyper V machines to use WSL Switch" >> $logPath ; 
         Get-VM | Get-VMNetworkAdapter | Connect-VMNetworkAdapter -SwitchName "WSL" ; 
         # now that host network is configured we can set up wsl network
+        Pause
         ConfigureWSLNetwork ;
         # Start All Hyper VMs
         Get-VM | Start-VM ;

--- a/resetWindowsNet.ps1
+++ b/resetWindowsNet.ps1
@@ -64,19 +64,15 @@ Do {
         # Set-NetAdapterBinding -Name "Ethernet" -ComponentID vms_pp -Enabled $False ;
 
         # identify non-virtual adapters with active network connection
-        $active = Get-CimInstance -ClassName Win32_NetworkAdapter | 
-            Select-Object -Property * |
-            Where-Object NetConnectionStatus -eq 2 | 
-            Where-Object Name -NotMatch 'Virtual' ;
-        
+        # $active[0] will be 1st net adapter in list while $active.[-1] will be last one
+        $active = Get-NetAdapter | Where-Object Status -eq up | Where-Object Name -NotMatch 'Virtual' ;
+  
         # Disable the vm adapter bound to active connection.
         ## Set-NetAdapterBinding -Name "Ethernet" -ComponentID vms_pp -Enabled $False ;
-        # the 'Name' properties across Cim and Get-Net don't match each other, 
-        # we are assuming Cim 'NetConnectionID' and Get-Net 'InterfaceAlias' are reliably synonymous
-        Set-NetAdapterBinding -InterfaceAlias $active.NetConnectionID -ComponentID vms_pp -Enabled $False ;
+        Set-NetAdapterBinding -Name $active[0].Name -ComponentID vms_pp -Enabled $False ;
 
         #Set-VMSwitch WSL -NetAdapterName "Ethernet" ;
-        Set-VMSwitch WSL -NetAdapterName $active.NetConnectionID ;
+        Set-VMSwitch WSL -NetAdapterName $active[0].Name ;
         $started = $true ;
         # Hook all Hyper V VMs to WSL network => avoid network performance issues.
         Write-Output  "Getting all Hyper V machines to use WSL Switch" >> $logPath ; 

--- a/troubleshooting-mhw.md
+++ b/troubleshooting-mhw.md
@@ -1,0 +1,71 @@
+# Set-VMSwitch : Failed while adding virtual Ethernet switch connections  #9    
+
+Set-VMSwitch : Failed while adding virtual Ethernet switch connections.
+Ethernet port '{EC88F1CA-81FD-421B-A395-FD47CD3BD45F}' bind failed: Element not found. (0x80070490).
+
+    At C:\Users\mhwilkie\code\WSL2-Network-Fix\resetWindowsNet.ps1:75 char:9
+    +         Set-VMSwitch WSL -NetAdapterName $active[0].Name ;
+    +         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        + CategoryInfo          : ObjectNotFound: (:) [Set-VMSwitch], VirtualizationException
+        + FullyQualifiedErrorId : ObjectNotFound,Microsoft.HyperV.PowerShell.Commands.SetVMSwitch
+
+
+
+> *My work around is to remove the Hyper-V feature. Reboot. Re-add the Hyper-V feature. Reboot. The Default switch is now set to "Internal network" and functions properly.*
+>
+>  *From <*[*https://borncity.com/win/2019/06/18/windows-10-v1903-ip-resolution-bug-in-hyper-v-switch/*](https://borncity.com/win/2019/06/18/windows-10-v1903-ip-resolution-bug-in-hyper-v-switch/)*>* 
+>
+>  *WORKAROUND: install Windows Sandbox (in addition to Hyper-V, in this case). Having Windows Sandbox installed seems to allow Windows to have what it needs to properly hand out a DHCP address.*
+>
+> *From* [*https://borncity.com/win/2019/06/18/windows-10-v1903-ip-resolution-bug-in-hyper-v-switch/*](https://borncity.com/win/2019/06/18/windows-10-v1903-ip-resolution-bug-in-hyper-v-switch/)
+>
+>  *1- ensure you have the WiFi drivers for your NIC. 2- run “netcfg -d” as admin. This will clean up anything in the NIC settings that might cause problems by totally removing all NIC info. 3- reboot 4- try adding the switch again.*
+>
+>  *From <*[*https://www.reddit.com/r/HyperV/comments/hsn56h/i_cannot_for_the_life_of_me_create_a_virtual/*](https://www.reddit.com/r/HyperV/comments/hsn56h/i_cannot_for_the_life_of_me_create_a_virtual/)*>* 
+>
+>  *Yeah corrupted drivers seemed to be the problem. It suddenly started working*
+>
+> *From <*[*https://www.reddit.com/r/HyperV/comments/hsn56h/i_cannot_for_the_life_of_me_create_a_virtual/*](https://www.reddit.com/r/HyperV/comments/hsn56h/i_cannot_for_the_life_of_me_create_a_virtual/)*>* 
+>
+> 
+>
+> ## Remedy #1 Cleaning net drivers
+
+    netcfg -d
+    shutdown /g
+
+After start up and logon:
+
+    ~~~
+    PS C:\Users\mhwilkie\code\WSL2-Network-Fix> Get-NetAdapter
+    
+    Name                      InterfaceDescription                    ifIndex Status       MacAddress             LinkSpeed
+    ----                      --------------------                    ------- ------       ----------             ---------
+    vEthernet (WSL)           Hyper-V Virtual Ethernet Adapter #2          22              00-15-5D-D7-FF-55          0 bps
+    VirtualBox Host-Only N... VirtualBox Host-Only Ethernet Adapter        19 Up           0A-00-27-00-00-13         1 Gbps
+    Wi-Fi                     Qualcomm(R) QCA6174A Extended Range ...      17 Up           10-5B-AD-32-3F-0B     144.4 Mbps
+    Ethernet 3                Check Point Virtual Network Adapter ...      13 Disconnected 54-5B-B3-13-42-0F         1 Gbps
+    vEthernet (Default Sw...2 Hyper-V Virtual Ethernet Adapter #3          58 Up           00-15-5D-64-10-2C        10 Gbps
+    vEthernet (Default Swi... Hyper-V Virtual Ethernet Adapter              8              00-15-5D-AA-CE-BD          0 bps
+    ~~~
+
+Interesting that there are 3 hyper-v adapters, 2 of which are disabled.
+And the Bridge has been removed too.
+
+...and that after launching a WSL console a new hyper-v adapter appears:
+
+    ~~~
+    Name                      InterfaceDescription                    ifIndex Status       MacAddress             LinkSpeed
+    ----                      --------------------                    ------- ------       ----------             ---------
+    vEthernet (WSL)           Hyper-V Virtual Ethernet Adapter #2          22              00-15-5D-D7-FF-55          0 bps
+    VirtualBox Host-Only N... VirtualBox Host-Only Ethernet Adapter        19 Up           0A-00-27-00-00-13         1 Gbps
+    Wi-Fi                     Qualcomm(R) QCA6174A Extended Range ...      17 Up           10-5B-AD-32-3F-0B     144.4 Mbps
+    Ethernet 3                Check Point Virtual Network Adapter ...      13 Disconnected 54-5B-B3-13-42-0F         1 Gbps
+    vEthernet (WSL) 2         Hyper-V Virtual Ethernet Adapter #4          66 Up           00-15-5D-AE-88-1D        10 Gbps
+    vEthernet (Default Sw...2 Hyper-V Virtual Ethernet Adapter #3          58 Up           00-15-5D-64-10-2C        10 Gbps
+    vEthernet (Default Swi... Hyper-V Virtual Ethernet Adapter              8              00-15-5D-AA-CE-BD          0 bps
+    ~~~
+
+Why did it not use the existing one? 
+And why is 'Delete' disabled in the Control Panel view of net adapters?
+

--- a/troubleshooting-mhw.md
+++ b/troubleshooting-mhw.md
@@ -67,5 +67,44 @@ And the Bridge has been removed too.
     ~~~
 
 Why did it not use the existing one? 
-And why is 'Delete' disabled in the Control Panel view of net adapters?
+And why is 'Delete' disabled in the Control Panel view of net adapters? And while there are psh commands for Get/Set and Enable/Disable-NetAdapter there are now remove or delete cmdlets. A curious ommission.
+
+Ok, let's try reset script again with this clean slate:
+
+```
+PS C:\Users\mhwilkie\code\WSL2-Network-Fix> .\resetWindowsNet.ps1                                   
+WSL Network found: VMSwitch (Name = 'WSL') [Id = '29d473f4-ca3a-4db2-9199-df69fb29c066']            
+Set-VMSwitch : Adding ports to the switch 'WSL' failed.                                             
+The operation failed because the object was not found.                                              
+At C:\Users\mhwilkie\code\WSL2-Network-Fix\resetWindowsNet.ps1:76 char:9                            
++         Set-VMSwitch WSL -NetAdapterName $active[0].Name ;                                        
++         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                          
+    + CategoryInfo          : ObjectNotFound: (:) [Set-VMSwitch], VirtualizationException           
+    + FullyQualifiedErrorId : ObjectNotFound,Microsoft.HyperV.PowerShell.Commands.SetVMSwitch       
+                                                                                                    
+Press Enter to continue...:                                                                         
+                                                                                                    
+Handles  NPM(K)    PM(K)      WS(K)     CPU(s)     Id  SI ProcessName                               
+-------  ------    -----      -----     ------     --  -- -----------                               
+    202      14     4692      11020       0.16  18048   1 wsl                                       
+    202      14     4692      11020       0.16  18048   1 wsl                                       
+0                                                                                                   
+```
+
+So last error was _Element_ not found and this one is _Object_ not found.
+
+```
+Name                      InterfaceDescription                    ifIndex Status       MacAddress             LinkSpeed
+----                      --------------------                    ------- ------       ----------             ---------
+vEthernet (WSL)           Hyper-V Virtual Ethernet Adapter #2          22              00-15-5D-D7-FF-55          0 bps
+VirtualBox Host-Only N... VirtualBox Host-Only Ethernet Adapter        19 Up           0A-00-27-00-00-13         1 Gbps
+Network Bridge            Microsoft Network Adapter Multiplexo...      40 Up           10-5B-AD-32-3F-0B     144.4 Mbps
+Wi-Fi                     Qualcomm(R) QCA6174A Extended Range ...      17 Up           10-5B-AD-32-3F-0B     144.4 Mbps
+Ethernet 3                Check Point Virtual Network Adapter ...      13 Disconnected 54-5B-B3-13-42-0F         1 Gbps
+vEthernet (WSL) 2         Hyper-V Virtual Ethernet Adapter #4          66 Up           00-15-5D-AE-88-1D        10 Gbps
+vEthernet (Default Sw...2 Hyper-V Virtual Ethernet Adapter #3          58 Up           00-15-5D-64-10-2C        10 Gbps
+vEthernet (Default Swi... Hyper-V Virtual Ethernet Adapter              8              00-15-5D-AA-CE-BD          0 bps
+```
+
+Also, our Bridge is back. So now we know it's *Set-VMSwitch* that creates it and not Network Troubleshooter like I'd surmised earlier,
 


### PR DESCRIPTION
Implements the ideas in #5, now with improved commands to get the active network adapters.

We now use the much more concise _Get-NetAdapter_ instead of _CimInstance_. Not only is the command shorter, the resulting array uses the same property names as the following commands. So no more confusing lookup tables trying to find matches, Name is Name everywhere, instead of sometimes InterfaceAlias = Name and sometimes something else.

If there are multiple active adapters we select the first one. Edit `$active[0]` to `$active[-1]` to use the last one instead.

I believe this should be functionally identical to the origin repo. It's not fully tested as I don't have everything working on my machine, however I my problems are unrelated to everything I've touched so far, I think. (I'll open more issues on these.)